### PR TITLE
Remove delightdriving.com

### DIFF
--- a/AdmiraList.txt
+++ b/AdmiraList.txt
@@ -230,7 +230,6 @@ decoycreation.com
 defectivesun.com
 defiantrice.com
 delegatediscussion.com
-delightdriving.com
 delightfulhour.com
 desertedbreath.com
 desertedrat.com


### PR DESCRIPTION
The site https://delightdriving.com appears legit.
Location is: 981 Bay St #4Staten Island, NY 10305
Phone number (347 343-2149) is also in local area.