### PR TITLE
Remove commandwalk.com

### DIFF
--- a/AdmiraList.txt
+++ b/AdmiraList.txt
@@ -178,7 +178,6 @@ coatfood.com
 colossalchance.com
 combclover.com
 comfortablecheese.com
-commandwalk.com
 commonswing.com
 completecabbage.com
 complextoad.com


### PR DESCRIPTION
https://commandwalk.com is not an Admiral site. 
It sells detection services for mobile ad fraud.