### PR TITLE
add aloofvest.com

### DIFF
--- a/AdmiraList.txt
+++ b/AdmiraList.txt
@@ -42,6 +42,7 @@ alleyarm.com
 alleyskin.com
 allowmailbox.com
 aloofmetal.com
+aloofvest.com
 amazingairplane.com
 ambiguousalarm.com
 ambiguousquilt.com


### PR DESCRIPTION
This PR adds the `aloofvest.com` domain to the list of known admiral domains.