### PR TITLE
Add mindfulgem.com

### DIFF
--- a/AdmiraList.txt
+++ b/AdmiraList.txt
@@ -728,6 +728,7 @@ metroaverage.com
 mightyspiders.com
 militaryverse.com
 mimosamajor.com
+mindfulgem.com
 mindlessmark.com
 minormeeting.com
 minuteburst.com


### PR DESCRIPTION
Noticed an Admiral popup on CBS News. After looking at Firefox DevTools network, found this domain making POST requests along with `cookielaw.org` and other non-Admiral things.
